### PR TITLE
Add Metadata 2.2 support.

### DIFF
--- a/tests/test_build_/test_build_additional_files.txt
+++ b/tests/test_build_/test_build_additional_files.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_additional_files_source_dir.txt
+++ b/tests/test_build_/test_build_additional_files_source_dir.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_complete_COMPLETE_A_.RECORD
+++ b/tests/test_build_/test_build_complete_COMPLETE_A_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_complete_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_complete_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_complete_COMPLETE_B_.RECORD
+++ b/tests/test_build_/test_build_complete_COMPLETE_B_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=xxqX2zIgwxgUCE1VgQnMOY0DAgSa-ddnpQwzq9PpmMs,1472
+whey-2021.0.0.dist-info/METADATA,sha256=8y-1C1IzjZjVaevM0cDZantWiiYQ0gC9ECV_K_G1Lak,1472
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_complete_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_complete_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_complete_LONG_REQUIREMENTS_.RECORD
+++ b/tests/test_build_/test_build_complete_LONG_REQUIREMENTS_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=aIi772Rlduow__WeM1MGu1-lRRSnZmB5wcGTBk0ei50,658
+whey-2021.0.0.dist-info/METADATA,sha256=YeshzZfvJxrtlwAtuAfftQdJ4qFt58hP2aiOCuHhnjA,658
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_complete_LONG_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_build_complete_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_complete_epoch_COMPLETE_A_.RECORD
+++ b/tests/test_build_/test_build_complete_epoch_COMPLETE_A_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_complete_epoch_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_complete_epoch_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_complete_epoch_COMPLETE_B_.RECORD
+++ b/tests/test_build_/test_build_complete_epoch_COMPLETE_B_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=xxqX2zIgwxgUCE1VgQnMOY0DAgSa-ddnpQwzq9PpmMs,1472
+whey-2021.0.0.dist-info/METADATA,sha256=8y-1C1IzjZjVaevM0cDZantWiiYQ0gC9ECV_K_G1Lak,1472
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_complete_epoch_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_complete_epoch_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_complete_epoch_LONG_REQUIREMENTS_.RECORD
+++ b/tests/test_build_/test_build_complete_epoch_LONG_REQUIREMENTS_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=aIi772Rlduow__WeM1MGu1-lRRSnZmB5wcGTBk0ei50,658
+whey-2021.0.0.dist-info/METADATA,sha256=YeshzZfvJxrtlwAtuAfftQdJ4qFt58hP2aiOCuHhnjA,658
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_complete_epoch_LONG_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_build_complete_epoch_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_0_2_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_editable_0_2_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_0_2_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_editable_0_2_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_0_2_LONG_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_build_editable_0_2_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_0_3_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_editable_0_3_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_0_3_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_editable_0_3_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_0_3_LONG_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_build_editable_0_3_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_editable_namespace.txt
+++ b/tests/test_build_/test_build_editable_namespace.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: default-values
 Version: 0.5.0
 Summary: Sphinx extension to show default values in documentation.

--- a/tests/test_build_/test_build_markdown_readme.RECORD
+++ b/tests/test_build_/test_build_markdown_readme.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=eyQt4O3RCByHYj4jn2aDomLwANFKl9D9lUWorV_M8xg,1475
+whey-2021.0.0.dist-info/METADATA,sha256=sWIMA-If3tkomjsTfdnlb5Hf8JTCkRTM88ISvNRrzvc,1475
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_markdown_readme.txt
+++ b/tests/test_build_/test_build_markdown_readme.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_source_dir_complete_COMPLETE_A_.RECORD
+++ b/tests/test_build_/test_build_source_dir_complete_COMPLETE_A_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_source_dir_complete_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_source_dir_complete_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_source_dir_complete_COMPLETE_B_.RECORD
+++ b/tests/test_build_/test_build_source_dir_complete_COMPLETE_B_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=xxqX2zIgwxgUCE1VgQnMOY0DAgSa-ddnpQwzq9PpmMs,1472
+whey-2021.0.0.dist-info/METADATA,sha256=8y-1C1IzjZjVaevM0cDZantWiiYQ0gC9ECV_K_G1Lak,1472
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_source_dir_complete_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_source_dir_complete_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_source_dir_different_package.RECORD
+++ b/tests/test_build_/test_build_source_dir_different_package.RECORD
@@ -1,6 +1,6 @@
 SpamSpam/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_source_dir_different_package.txt
+++ b/tests/test_build_/test_build_source_dir_different_package.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_stubs_name.txt
+++ b/tests/test_build_/test_build_stubs_name.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam-spam-stubs
 Version: 2020.0.0

--- a/tests/test_build_/test_build_success_authors_.txt
+++ b/tests/test_build_/test_build_success_authors_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Author-email: hi@pradyunsg.me

--- a/tests/test_build_/test_build_success_classifiers_.txt
+++ b/tests/test_build_/test_build_success_classifiers_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Classifier: Development Status :: 4 - Beta

--- a/tests/test_build_/test_build_success_dependencies_.txt
+++ b/tests/test_build_/test_build_success_dependencies_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Dist: django>2.1; os_name != "nt"

--- a/tests/test_build_/test_build_success_description_.txt
+++ b/tests/test_build_/test_build_success_description_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Summary: Lovely Spam! Wonderful Spam!

--- a/tests/test_build_/test_build_success_entry_points_.txt
+++ b/tests/test_build_/test_build_success_entry_points_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0

--- a/tests/test_build_/test_build_success_keywords_.txt
+++ b/tests/test_build_/test_build_success_keywords_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Keywords: bacon,egg,Lobster Thermidor,sausage,tomatoes

--- a/tests/test_build_/test_build_success_maintainers_.txt
+++ b/tests/test_build_/test_build_success_maintainers_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Author-email: Brett Cannon <brett@python.org>

--- a/tests/test_build_/test_build_success_minimal_.txt
+++ b/tests/test_build_/test_build_success_minimal_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0

--- a/tests/test_build_/test_build_success_optional_dependencies_.txt
+++ b/tests/test_build_/test_build_success_optional_dependencies_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Dist: matplotlib>=3.0.0; (platform_machine != "aarch64" or python_version > "3.6") and extra == 'test'

--- a/tests/test_build_/test_build_success_requires_python_.txt
+++ b/tests/test_build_/test_build_success_requires_python_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Python: >=3.8

--- a/tests/test_build_/test_build_success_requires_python_complex_.txt
+++ b/tests/test_build_/test_build_success_requires_python_complex_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Python: !=3.0.*,!=3.2.*,>=2.7

--- a/tests/test_build_/test_build_success_unicode_.txt
+++ b/tests/test_build_/test_build_success_unicode_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Summary: Factory ⸻ A code generator 🏭

--- a/tests/test_build_/test_build_success_urls_.txt
+++ b/tests/test_build_/test_build_success_urls_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Home-page: example.com

--- a/tests/test_build_/test_build_underscore_name_hyphen_name_underscore_package_explicit_.txt
+++ b/tests/test_build_/test_build_underscore_name_hyphen_name_underscore_package_explicit_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam-spam
 Version: 2020.0.0

--- a/tests/test_build_/test_build_underscore_name_hyphen_name_underscore_package_implicit_.txt
+++ b/tests/test_build_/test_build_underscore_name_hyphen_name_underscore_package_implicit_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam-spam
 Version: 2020.0.0

--- a/tests/test_build_/test_build_underscore_name_underscore_name_.txt
+++ b/tests/test_build_/test_build_underscore_name_underscore_name_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam-spam
 Version: 2020.0.0

--- a/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_A_.RECORD
+++ b/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_A_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_B_.RECORD
+++ b/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_B_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=xxqX2zIgwxgUCE1VgQnMOY0DAgSa-ddnpQwzq9PpmMs,1472
+whey-2021.0.0.dist-info/METADATA,sha256=8y-1C1IzjZjVaevM0cDZantWiiYQ0gC9ECV_K_G1Lak,1472
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_wheel_from_sdist_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_wheel_from_sdist_DYNAMIC_REQUIREMENTS_.RECORD
+++ b/tests/test_build_/test_build_wheel_from_sdist_DYNAMIC_REQUIREMENTS_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_wheel_from_sdist_DYNAMIC_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_build_wheel_from_sdist_DYNAMIC_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_wheel_from_sdist_LONG_REQUIREMENTS_.RECORD
+++ b/tests/test_build_/test_build_wheel_from_sdist_LONG_REQUIREMENTS_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=aIi772Rlduow__WeM1MGu1-lRRSnZmB5wcGTBk0ei50,658
+whey-2021.0.0.dist-info/METADATA,sha256=YeshzZfvJxrtlwAtuAfftQdJ4qFt58hP2aiOCuHhnjA,658
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_wheel_from_sdist_LONG_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_build_wheel_from_sdist_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_A_.RECORD
+++ b/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_A_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_A_.txt
+++ b/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_B_.RECORD
+++ b/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_B_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=xxqX2zIgwxgUCE1VgQnMOY0DAgSa-ddnpQwzq9PpmMs,1472
+whey-2021.0.0.dist-info/METADATA,sha256=8y-1C1IzjZjVaevM0cDZantWiiYQ0gC9ECV_K_G1Lak,1472
 whey-2021.0.0.dist-info/WHEEL,sha256=Z8ApXUcOYK5VMz9yebTyUF13KAMNT6RSnd-lLcivEVA,84
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_B_.txt
+++ b/tests/test_build_/test_build_wheel_from_sdist_source_dir_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_custom_wheel_builder_COMPLETE_A_.RECORD
+++ b/tests/test_build_/test_custom_wheel_builder_COMPLETE_A_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=8iiyYruvYnQXM7I-Boj7lpKCU2Pz8W1dy2Df1tBKXZ4,1410
+whey-2021.0.0.dist-info/METADATA,sha256=Kt-Pv11iCkvNL7YcilCNYD7iYBD4mXWCg-p_PGdn49Q,1410
 whey-2021.0.0.dist-info/WHEEL,sha256=r2SGDgzin6Yt4GzNx_Bg7ya-CuSBkCRIHxIIrSDZ-FM,95
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_custom_wheel_builder_COMPLETE_A_.txt
+++ b/tests/test_build_/test_custom_wheel_builder_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_custom_wheel_builder_COMPLETE_B_.RECORD
+++ b/tests/test_build_/test_custom_wheel_builder_COMPLETE_B_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=xxqX2zIgwxgUCE1VgQnMOY0DAgSa-ddnpQwzq9PpmMs,1472
+whey-2021.0.0.dist-info/METADATA,sha256=8y-1C1IzjZjVaevM0cDZantWiiYQ0gC9ECV_K_G1Lak,1472
 whey-2021.0.0.dist-info/WHEEL,sha256=r2SGDgzin6Yt4GzNx_Bg7ya-CuSBkCRIHxIIrSDZ-FM,95
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_custom_wheel_builder_COMPLETE_B_.txt
+++ b/tests/test_build_/test_custom_wheel_builder_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_build_/test_custom_wheel_builder_LONG_REQUIREMENTS_.RECORD
+++ b/tests/test_build_/test_custom_wheel_builder_LONG_REQUIREMENTS_.RECORD
@@ -1,6 +1,6 @@
 whey/__init__.py,sha256=LVQwFWJ6dxQ2sw6nn9Ds2o34vNd7PVVmHK9aDW6AmIY,21
 whey-2021.0.0.dist-info/LICENSE,sha256=5wizT6r_v4VTz5CuAQ2HSwrPhYUFwQypVskUSmY1reQ,20
-whey-2021.0.0.dist-info/METADATA,sha256=aIi772Rlduow__WeM1MGu1-lRRSnZmB5wcGTBk0ei50,658
+whey-2021.0.0.dist-info/METADATA,sha256=YeshzZfvJxrtlwAtuAfftQdJ4qFt58hP2aiOCuHhnjA,658
 whey-2021.0.0.dist-info/WHEEL,sha256=r2SGDgzin6Yt4GzNx_Bg7ya-CuSBkCRIHxIIrSDZ-FM,95
 whey-2021.0.0.dist-info/entry_points.txt,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 whey-2021.0.0.dist-info/RECORD,,

--- a/tests/test_build_/test_custom_wheel_builder_LONG_REQUIREMENTS_.txt
+++ b/tests/test_build_/test_custom_wheel_builder_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_config_/test_parse_builders.yml
+++ b/tests/test_config_/test_parse_builders.yml
@@ -15,9 +15,7 @@ classifiers:
 - 'Programming Language :: Python :: Implementation :: PyPy'
 dependencies: []
 description: A simple Python wheel builder for simple projects.
-dynamic:
-- classifiers
-- requires-python
+dynamic: []
 entry-points: {}
 gui-scripts: {}
 keywords:

--- a/tests/test_config_/test_parse_dynamic_requirements.yml
+++ b/tests/test_config_/test_parse_dynamic_requirements.yml
@@ -26,10 +26,7 @@ dependencies:
 - shippinglabel>=0.10.0
 - toml>=0.10.2
 description: A simple Python wheel builder for simple projects.
-dynamic:
-- classifiers
-- requires-python
-- dependencies
+dynamic: []
 entry-points: {}
 gui-scripts: {}
 keywords:

--- a/tests/test_config_/test_parse_valid_config_COMPLETE_A_.yml
+++ b/tests/test_config_/test_parse_valid_config_COMPLETE_A_.yml
@@ -21,9 +21,7 @@ dependencies:
 - gidgethub[httpx]>4.0.0
 - httpx
 description: A simple Python wheel builder for simple projects.
-dynamic:
-- classifiers
-- requires-python
+dynamic: []
 entry-points: {}
 gui-scripts: {}
 keywords:

--- a/tests/test_config_/test_parse_valid_config_COMPLETE_B_.yml
+++ b/tests/test_config_/test_parse_valid_config_COMPLETE_B_.yml
@@ -24,9 +24,7 @@ dependencies:
 - gidgethub[httpx]>4.0.0
 - httpx
 description: A simple Python wheel builder for simple projects.
-dynamic:
-- classifiers
-- requires-python
+dynamic: []
 entry-points: {}
 gui-scripts: {}
 keywords:

--- a/tests/test_config_/test_parse_valid_config_COMPLETE_B_ADDITIONAL_FILES_.yml
+++ b/tests/test_config_/test_parse_valid_config_COMPLETE_B_ADDITIONAL_FILES_.yml
@@ -36,9 +36,7 @@ dependencies:
 - gidgethub[httpx]>4.0.0
 - httpx
 description: A simple Python wheel builder for simple projects.
-dynamic:
-- classifiers
-- requires-python
+dynamic: []
 entry-points: {}
 gui-scripts: {}
 keywords:

--- a/tests/test_foreman_/test_build_additional_files.txt
+++ b/tests/test_foreman_/test_build_additional_files.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_foreman_/test_build_complete_COMPLETE_A_.txt
+++ b/tests/test_foreman_/test_build_complete_COMPLETE_A_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_foreman_/test_build_complete_COMPLETE_B_.txt
+++ b/tests/test_foreman_/test_build_complete_COMPLETE_B_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_foreman_/test_build_complete_LONG_REQUIREMENTS_.txt
+++ b/tests/test_foreman_/test_build_complete_LONG_REQUIREMENTS_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: whey
 Version: 2021.0.0
 Summary: A simple Python wheel builder for simple projects.

--- a/tests/test_foreman_/test_build_success_authors_.txt
+++ b/tests/test_foreman_/test_build_success_authors_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Author-email: hi@pradyunsg.me

--- a/tests/test_foreman_/test_build_success_classifiers_.txt
+++ b/tests/test_foreman_/test_build_success_classifiers_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Classifier: Development Status :: 4 - Beta

--- a/tests/test_foreman_/test_build_success_dependencies_.txt
+++ b/tests/test_foreman_/test_build_success_dependencies_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Dist: django>2.1; os_name != "nt"

--- a/tests/test_foreman_/test_build_success_description_.txt
+++ b/tests/test_foreman_/test_build_success_description_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Summary: Lovely Spam! Wonderful Spam!

--- a/tests/test_foreman_/test_build_success_entry_points_.txt
+++ b/tests/test_foreman_/test_build_success_entry_points_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0

--- a/tests/test_foreman_/test_build_success_keywords_.txt
+++ b/tests/test_foreman_/test_build_success_keywords_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Keywords: bacon,egg,Lobster Thermidor,sausage,tomatoes

--- a/tests/test_foreman_/test_build_success_maintainers_.txt
+++ b/tests/test_foreman_/test_build_success_maintainers_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Author-email: Brett Cannon <brett@python.org>

--- a/tests/test_foreman_/test_build_success_minimal_.txt
+++ b/tests/test_foreman_/test_build_success_minimal_.txt
@@ -1,3 +1,3 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0

--- a/tests/test_foreman_/test_build_success_optional_dependencies_.txt
+++ b/tests/test_foreman_/test_build_success_optional_dependencies_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Dist: matplotlib>=3.0.0; (platform_machine != "aarch64" or python_version > "3.6") and extra == 'test'

--- a/tests/test_foreman_/test_build_success_requires_python_.txt
+++ b/tests/test_foreman_/test_build_success_requires_python_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Python: >=3.8

--- a/tests/test_foreman_/test_build_success_requires_python_complex_.txt
+++ b/tests/test_foreman_/test_build_success_requires_python_complex_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Requires-Python: !=3.0.*,!=3.2.*,>=2.7

--- a/tests/test_foreman_/test_build_success_unicode_.txt
+++ b/tests/test_foreman_/test_build_success_unicode_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Summary: Factory ⸻ A code generator 🏭

--- a/tests/test_foreman_/test_build_success_urls_.txt
+++ b/tests/test_foreman_/test_build_success_urls_.txt
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.2
 Name: spam
 Version: 2020.0.0
 Home-page: example.com

--- a/whey/builder.py
+++ b/whey/builder.py
@@ -390,9 +390,7 @@ class AbstractBuilder(ABC):
 
 		metadata_mapping = MetadataMapping()
 
-		# TODO: metadata 2.2
-		# Need to translate pep621 dynamic into core metadata field names
-		metadata_mapping["Metadata-Version"] = "2.1"
+		metadata_mapping["Metadata-Version"] = "2.2"
 		metadata_mapping["Name"] = self.config["name"]
 		metadata_mapping["Version"] = str(self.config["version"])
 

--- a/whey/builder.py
+++ b/whey/builder.py
@@ -402,6 +402,7 @@ class AbstractBuilder(ABC):
 			for value in self.config[key]:
 				metadata_mapping[field] = str(value)  # pylint: disable=loop-invariant-statement
 
+		add_multiple("dynamic", "Dynamic")
 		metadata_mapping.update(self.parse_authors())
 
 		add_not_none("description", "Summary")
@@ -463,7 +464,7 @@ class AbstractBuilder(ABC):
 		:param metadata_file:
 		"""
 
-		metadata_file.write_text(metadata.dumps(metadata_mapping))
+		metadata_file.write_clean(metadata.dumps(metadata_mapping))
 		self.report_written(metadata_file)
 
 	def call_additional_hooks(self) -> None:


### PR DESCRIPTION
Currently whey only supports `classifiers`, `requires-python`, and `dependencies` as dynamic, and will backfill values for those into pyproject.toml. For now it's safe to assume pyproject.toml and PKG-INFO will match in an sdist and skip parsing PKG-INFO.